### PR TITLE
Made it work with moderncv 0.15.1

### DIFF
--- a/moderntimeline.dtx
+++ b/moderntimeline.dtx
@@ -410,7 +410,7 @@
 %
 % \begin{macro}{\tldatelabelcventry}
 %    \begin{macrocode}
-\newcommand{\tldatelabelcventry}[8][sectionrectanglecolor]{%
+\newcommand{\tldatelabelcventry}[8][color1]{%
 %    \end{macrocode}
 %    \begin{macrocode}
 \pgfmathsetmacro\tl@endyear{\tl@lastyear}
@@ -434,7 +434,7 @@
 %
 % \begin{macro}{\tldatecventry}
 %    \begin{macrocode}
-\newcommand{\tldatecventry}[7][sectionrectanglecolor]{%
+\newcommand{\tldatecventry}[7][color1]{%
 %    \end{macrocode}
 %    \begin{macrocode}
 \pgfmathsetmacro\tl@endyear{\tl@lastyear}%
@@ -457,7 +457,7 @@
 %
 % \begin{macro}{\tlcventry}
 %    \begin{macrocode}
-\newcommand{\tlcventry}[8][sectionrectanglecolor]{%
+\newcommand{\tlcventry}[8][color1]{%
 %    \end{macrocode}
 %    \begin{macrocode}
 \pgfmathsetmacro\tl@endyear{ifthenelse(#3==0,\tl@lastyear,#3)}%
@@ -490,7 +490,7 @@
 %
 % \begin{macro}{\tllabelcventry}
 %    \begin{macrocode}
-\newcommand{\tllabelcventry}[9][sectionrectanglecolor]{%
+\newcommand{\tllabelcventry}[9][color1]{%
 %    \end{macrocode}
 %    \begin{macrocode}
 \pgfmathsetmacro\tl@endyear{ifthenelse(#3==0,\tl@lastyear,#3)}


### PR DESCRIPTION
I've got 2 errors when using it with the latest version of moderncv:

The first was in `\tllabelcventry` where `tl@endyear.north` was used. I fixed it by setting it to 0pt like in the other commands.

The second error was caused by changes in moderncv. In moderncv 0.15.1 `sectionrectanglecolor` is no longer defined and was replaced by `color1`.
