### PR TITLE
Add support for timeline bar marks.

### DIFF
--- a/moderntimeline.dtx
+++ b/moderntimeline.dtx
@@ -43,7 +43,7 @@
 %</driver>
 % \fi
 %
-% \CheckSum{352}
+% \CheckSum{413}
 %
 % \CharacterTable
 %  {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
@@ -752,7 +752,7 @@
 (\tl@startfraction*\hintscolumnwidth,0)
            rectangle (\fullcolorwidth,\tl@width);
        \shade [left color=#1] (\fullcolorwidth,0)
-           rectangle (\tl@endfraction*\hintscolumnwidth,\tl@width);
+           rectangle (\tl@endfraction*\hintscolumnwidth + 1,\tl@width);
     \else
        \fill [#1] (\tl@startfraction*\hintscolumnwidth,0)
            rectangle (\tl@endfraction*\hintscolumnwidth,\tl@width);

--- a/moderntimeline.dtx
+++ b/moderntimeline.dtx
@@ -102,13 +102,15 @@
 % and can be loaded with:
 %
 % \begin{verbatim}
-%    \usepackage[firstyear=1999,lastyear=2012,marksyr=0.4ex,marksmo=0.2ex]{moderntimeline}
+%    \usepackage[firstyear=1999,lastyear=2012,
+%                marksyr=0.4ex,marksmo=0.2ex
+%                ]{moderntimeline}
 % \end{verbatim}
 %
 % The \texttt{firstyear} and \texttt{lastyear} options indicate the maximum dates used
 % to calibrate the time line. They are not mandatory and can be set later
 % by means of the |\ltmaxdates| macro.
-% The \texttt{marksyr} and \texttt{marksmo} options behave exactle the same as
+% The \texttt{marksyr} and \texttt{marksmo} options behave exactly the same as
 % the |\tlenablemarksyr| and |\tlenablemarksmo| (and associated) macros.
 %
 % \subsection{Settings}

--- a/moderntimeline.dtx
+++ b/moderntimeline.dtx
@@ -228,6 +228,21 @@
 % the beginning of the year, so is not advisable to use months in dates.
 % Default.
 %
+% \DescribeMacro{\tlenablemarksmo}
+% This macro places vertical lines on the timeline bar at every month and year.
+% You can set the height of the marks with |\tlmarkheightmo| (default = 0.2ex).
+%
+% \DescribeMacro{\tlenablemakrsyr}
+% This macro places vertical lines on the timeline bar at every year.
+% You can set the height of the marks with |\tlmarkheightyr| (default = 0.4ex).
+%
+% \DescribeMacro{\tldisablemarksyr}
+% Disables the vertical lines marking years on the timeline bar.
+% This is the opposite of |\tlenablemarksyr|.
+%
+% \DescribeMacro{\tldisablemarksmo}
+% Disables the vertical lines marking months and years on the timeline bar.
+% This is the opposite of |\tlenablemarksmo|.
 %
 % \subsection{CV entries}
 %
@@ -344,6 +359,8 @@
 \ProcessKeyvalOptions*
 \newif\ifstartyear
 \newif\ifissince
+\newif\ifshowmarksyr
+\newif\ifshowmarksmo
 %    \end{macrocode}
 %
 % \begin{macro}{\tlwidth}
@@ -367,6 +384,22 @@
 %    \begin{macrocode}
 \newcommand{\tlrunningcolor}[1]{%
    \def\tl@runningcolor{#1}
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\tlmarkheightmo}
+%    \begin{macrocode}
+\newcommand{\tlmarkheightmo}[1]{%
+    \def\tl@markheightmo{#1}
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\tlmarkheightyr}
+%    \begin{macrocode}
+\newcommand{\tlmarkheightyr}[1]{%
+    \def\tl@markheightyr{#1}
 }
 %    \end{macrocode}
 % \end{macro}
@@ -469,6 +502,42 @@
 % \end{macro}
 %
 %
+% \begin{macro}{\tldisablemarksyr}
+%    \begin{macrocode}
+\newcommand{\tldisablemarksyr}{%
+    \showmarksyrfalse
+}
+%    \end{macrocode}
+% \end{macro}
+%
+%
+% \begin{macro}{\tlenablemarksyr}
+%    \begin{macrocode}
+\newcommand{\tlenablemarksyr}{%
+    \showmarksyrtrue
+}
+%    \end{macrocode}
+% \end{macro}
+%
+%
+% \begin{macro}{\tldisablemarksmo}
+%    \begin{macrocode}
+\newcommand{\tldisablemarksmo}{%
+    \showmarksmofalse
+}
+%    \end{macrocode}
+% \end{macro}
+%
+%
+% \begin{macro}{\tlenablemarksmo}
+%    \begin{macrocode}
+\newcommand{\tlenablemarksmo}{%
+    \showmarksmotrue
+}
+%    \end{macrocode}
+% \end{macro}
+%
+%
 % Defaults
 %    \begin{macrocode}
 \tltext{\scriptsize}
@@ -478,6 +547,8 @@
 \tlsince{}
 \tlsetnotshadedfraction{0}
 \tldisablemonths
+\tlmarkheightmo{0.2ex}
+\tlmarkheightyr{0.4ex}
 %    \end{macrocode}
 %
 %
@@ -487,6 +558,10 @@
    \def\tl@firstyear{#1}
    \def\tl@lastyear{#2}
    \pgfmathsetmacro\tl@yearrange{\tl@lastyear-\tl@firstyear}
+   \pgfmathsetmacro\tl@totalyears{\tl@lastyear-\tl@firstyear}%
+   \pgfmathsetmacro\tl@totalmonths{12*\tl@totalyears}%
+   \pgfmathsetmacro\tl@tickdistmo{\hintscolumnwidth/\tl@totalmonths}%
+   \pgfmathsetmacro\tl@tickdistyr{\hintscolumnwidth/\tl@totalyears}%
 }
 %    \end{macrocode}
 % \end{macro}
@@ -528,6 +603,24 @@
   \else
     \pgfmathsetmacro\tl@tmpmonth{#1}%
   \fi
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\tl@tlcvbar}
+%    \begin{macrocode}
+\newcommand{\tl@tlcvbar}{
+    \useasboundingbox (0,-1.5ex) rectangle (\hintscolumnwidth,1ex);
+    \fill [\tl@runningcolor] (0,0)
+    rectangle (\hintscolumnwidth,\tl@runningwidth);
+    \ifshowmarksyr
+        \foreach \x in {0, ..., \tl@totalyears}
+        \draw [\tl@runningcolor](\x*\tl@tickdistyr pt,0ex) -- (\x*\tl@tickdistyr pt,\tl@markheightyr);
+    \fi
+    \ifshowmarksmo
+        \foreach \x in {0, ..., \tl@totalmonths}
+        \draw [\tl@runningcolor](\x*\tl@tickdistmo pt,0ex) -- (\x*\tl@tickdistmo pt,\tl@markheightmo);
+    \fi
 }
 %    \end{macrocode}
 % \end{macro}
@@ -605,9 +698,7 @@
 \issincefalse
 \tl@formatstartyear{#2}
 \cventry{\tikz[baseline=0pt]{
-    \useasboundingbox (0,-1.5ex) rectangle (\hintscolumnwidth,1ex);
-     \fill [\tl@runningcolor] (0,0)
-        rectangle (\hintscolumnwidth,\tl@runningwidth);
+    \tl@tlcvbar
      \fill [#1] (0,0)
         ++(\tl@startfraction*\hintscolumnwidth,0pt)
         node [tl@startyear] {#3}
@@ -627,9 +718,7 @@
 \issincefalse
 \tl@formatstartyear{#2}
 \cventry{\tikz[baseline=0pt]{
-    \useasboundingbox (0,-1.5ex) rectangle (\hintscolumnwidth,1ex);
-    \fill [\tl@runningcolor] (0,0)
-       rectangle (\hintscolumnwidth,\tl@runningwidth);
+    \tl@tlcvbar
     \fill [#1] (0,0)
        ++(\tl@startfraction*\hintscolumnwidth,0pt)
        node [tl@singleyear] {#2}
@@ -649,9 +738,7 @@
 \tl@formatendyear{#3}
 \tl@formatstartyear{#2}
  \cventry{\tikz[baseline=0pt]{
-    \useasboundingbox (0,-1.5ex) rectangle (\hintscolumnwidth,1ex);
-    \fill [\tl@runningcolor] (0,0)
-       rectangle (\hintscolumnwidth,\tl@runningwidth);
+    \tl@tlcvbar
     \fill [#1] (0,0)
        ++(\tl@startfraction*\hintscolumnwidth,0pt)
        node [tl@startyear] {\tl@startlabel}
@@ -686,10 +773,7 @@
 \tl@formatstartyear{#2}
 \tl@splitlabels{#4}
  \cventry{\tikz[baseline=0pt]{
-     \fill [\tl@runningcolor] (0,0)
-        rectangle (\hintscolumnwidth,\tl@runningwidth);
-     \useasboundingbox (0,-1.5ex)
-        rectangle (\hintscolumnwidth,1ex);
+     \tl@tlcvbar
      \fill [#1] (0,0)
         ++(\tl@startfraction*\hintscolumnwidth,0pt)
         node [tl@startyear] {\tl@startlabel}

--- a/moderntimeline.dtx
+++ b/moderntimeline.dtx
@@ -102,12 +102,14 @@
 % and can be loaded with:
 %
 % \begin{verbatim}
-%    \usepackage[firstyear=1999,lastyear=2012]{moderntimeline}
+%    \usepackage[firstyear=1999,lastyear=2012,marksyr=0.4ex,marksmo=0.2ex]{moderntimeline}
 % \end{verbatim}
 %
 % The \texttt{firstyear} and \texttt{lastyear} options indicate the maximum dates used
 % to calibrate the time line. They are not mandatory and can be set later
 % by means of the |\ltmaxdates| macro.
+% The \texttt{marksyr} and \texttt{marksmo} options behave exactle the same as
+% the |\tlenablemarksyr| and |\tlenablemarksmo| (and associated) macros.
 %
 % \subsection{Settings}
 %
@@ -356,11 +358,11 @@
 }
 \DeclareStringOption{firstyear}
 \DeclareStringOption{lastyear}
+\DeclareStringOption{marksmo}[0.2ex]
+\DeclareStringOption{marksyr}[0.4ex]
 \ProcessKeyvalOptions*
 \newif\ifstartyear
 \newif\ifissince
-\newif\ifshowmarksyr
-\newif\ifshowmarksmo
 %    \end{macrocode}
 %
 % \begin{macro}{\tlwidth}
@@ -391,7 +393,7 @@
 % \begin{macro}{\tlmarkheightmo}
 %    \begin{macrocode}
 \newcommand{\tlmarkheightmo}[1]{%
-    \def\tl@markheightmo{#1}
+    \def\tl@marksmo{#1}
 }
 %    \end{macrocode}
 % \end{macro}
@@ -399,7 +401,7 @@
 % \begin{macro}{\tlmarkheightyr}
 %    \begin{macrocode}
 \newcommand{\tlmarkheightyr}[1]{%
-    \def\tl@markheightyr{#1}
+    \def\tl@marksyr{#1}
 }
 %    \end{macrocode}
 % \end{macro}
@@ -505,7 +507,7 @@
 % \begin{macro}{\tldisablemarksyr}
 %    \begin{macrocode}
 \newcommand{\tldisablemarksyr}{%
-    \showmarksyrfalse
+    \def\tl@marksyr{}
 }
 %    \end{macrocode}
 % \end{macro}
@@ -514,7 +516,7 @@
 % \begin{macro}{\tlenablemarksyr}
 %    \begin{macrocode}
 \newcommand{\tlenablemarksyr}{%
-    \showmarksyrtrue
+    \def\tl@marksyr{0.4ex}
 }
 %    \end{macrocode}
 % \end{macro}
@@ -523,7 +525,7 @@
 % \begin{macro}{\tldisablemarksmo}
 %    \begin{macrocode}
 \newcommand{\tldisablemarksmo}{%
-    \showmarksmofalse
+    \def\tl@marksmo{}
 }
 %    \end{macrocode}
 % \end{macro}
@@ -532,7 +534,7 @@
 % \begin{macro}{\tlenablemarksmo}
 %    \begin{macrocode}
 \newcommand{\tlenablemarksmo}{%
-    \showmarksmotrue
+    \def\tl@marksmo{0.2ex}
 }
 %    \end{macrocode}
 % \end{macro}
@@ -547,8 +549,6 @@
 \tlsince{}
 \tlsetnotshadedfraction{0}
 \tldisablemonths
-\tlmarkheightmo{0.2ex}
-\tlmarkheightyr{0.4ex}
 %    \end{macrocode}
 %
 %
@@ -558,10 +558,6 @@
    \def\tl@firstyear{#1}
    \def\tl@lastyear{#2}
    \pgfmathsetmacro\tl@yearrange{\tl@lastyear-\tl@firstyear}
-   \pgfmathsetmacro\tl@totalyears{\tl@lastyear-\tl@firstyear}%
-   \pgfmathsetmacro\tl@totalmonths{12*\tl@totalyears}%
-   \pgfmathsetmacro\tl@tickdistmo{\hintscolumnwidth/\tl@totalmonths}%
-   \pgfmathsetmacro\tl@tickdistyr{\hintscolumnwidth/\tl@totalyears}%
 }
 %    \end{macrocode}
 % \end{macro}
@@ -610,16 +606,20 @@
 % \begin{macro}{\tl@tlcvbar}
 %    \begin{macrocode}
 \newcommand{\tl@tlcvbar}{
+    \pgfmathsetmacro\tl@yearrange{\tl@lastyear-\tl@firstyear}
+    \pgfmathsetmacro\tl@totalmonths{12*\tl@yearrange}%
+    \pgfmathsetmacro\tl@tickdistmo{\hintscolumnwidth/\tl@totalmonths}%
+    \pgfmathsetmacro\tl@tickdistyr{\hintscolumnwidth/\tl@yearrange}%
     \useasboundingbox (0,-1.5ex) rectangle (\hintscolumnwidth,1ex);
     \fill [\tl@runningcolor] (0,0)
     rectangle (\hintscolumnwidth,\tl@runningwidth);
-    \ifshowmarksyr
-        \foreach \x in {0, ..., \tl@totalyears}
-        \draw [\tl@runningcolor](\x*\tl@tickdistyr pt,0ex) -- (\x*\tl@tickdistyr pt,\tl@markheightyr);
+    \ifx\tl@marksyr\empty\relax\else
+        \foreach \x in {0, ..., \tl@yearrange}
+        \draw [\tl@runningcolor](\x*\tl@tickdistyr pt,0ex) -- (\x*\tl@tickdistyr pt,\tl@marksyr);
     \fi
-    \ifshowmarksmo
+    \ifx\tl@marksmo\empty\relax\else
         \foreach \x in {0, ..., \tl@totalmonths}
-        \draw [\tl@runningcolor](\x*\tl@tickdistmo pt,0ex) -- (\x*\tl@tickdistmo pt,\tl@markheightmo);
+        \draw [\tl@runningcolor](\x*\tl@tickdistmo pt,0ex) -- (\x*\tl@tickdistmo pt,\tl@marksmo);
     \fi
 }
 %    \end{macrocode}

--- a/spec/pdf_spec.rb
+++ b/spec/pdf_spec.rb
@@ -2,8 +2,8 @@ require 'pdf/reader'
 
 describe 'Moderntimeline PDF' do
   reader = PDF::Reader.new('moderntimeline.pdf')
-  it 'should have 12 pages' do
-    reader.page_count.should eq(12)
+  it 'should have 13 pages' do
+    reader.page_count.should eq(13)
   end
   it 'should be made by TeX' do
     reader.info[:Creator].should eq('TeX')


### PR DESCRIPTION
This PR implements the timeline bar marks mentioned in #16. I added the following macros:
- \tl@tlcvbar (Creates the timeline bar, exists to avoid code repititon.)
- \tlenablemarksyr
- \tldisablemarksyr
- \tlenablemarksmo
- \tlenablemarksyr
- \tlmarkheightmo (1 parameter, default = 0.2ex)
- \tlmarkheightyr (1 parameter, default = 0.4ex)

By default all marks are disabled and the bar will look like normal.

**Example output**
```LaTeX
\documentclass[11pt,a4paper,sans]{moderncv}
\moderncvstyle{casual}
\moderncvcolor{blue}
\usepackage{moderntimeline}
\tlmaxdates{2017}{2023}
\tlwidth{0.8ex}
\tltext{\tiny}
\name{Test}{Test}
\tlenablemonths
\tlenablemarksyr
\begin{document}
    \tlcventry[blue]{2019}{0}{}{}{}{}{}
    \tlcventry[purple]{2018/3}{2019}{}{}{}{}{}
    \tldatecventry[green]{2019/7}{}{}{}{}{}
    \tlcventry[blue]{2018/1}{2019}{}{}{}{}{}
    \tlcventry[red]{2018/3}{2018/12}{}{}{}{}{}
    \tlcventry[purple]{2018}{2019/12}{}{}{}{}{}
    \tlcventry[green]{2018/12}{2019/1}{}{}{}{}{}
    \tlcventry[green]{2019/1}{2019/2}{}{}{}{}{}
    \tlcventry[red]{2019/1}{2019/12}{}{}{}{}{}
    \tlcventry[purple]{2018}{2019}{}{}{}{}{}
    \tldatecventry[green]{2019}{}{}{}{}{}
    \tldatecventry[blue]{2019/12}{}{}{}{}{}
    \tldatecventry[red]{2019/1}{}{}{}{}{}
\end{document}
```
![Example timeline with marks](https://i.ibb.co/PTJG64D/upload.png)

