### PR TITLE
Fix label positioning of \tldatelabelcventry

### DIFF
--- a/moderntimeline.dtx
+++ b/moderntimeline.dtx
@@ -704,7 +704,7 @@
     \tl@tlcvbar
      \fill [#1] (0,0)
         ++(\tl@startfraction*\hintscolumnwidth,0pt)
-        node [tl@startyear] {#3}
+        node [tl@singleyear] {#3}
         node {$\bullet$};
    }
 }


### PR DESCRIPTION
Currently, when using `\tldatelabelcventry`, the label will not show up centered above the date bullet like it is the case for `\tldatecventry`. This little PR fixes that, making the behavior of both macros consistent.