### PR TITLE
Fix typo in description of macro `\tlenablemarksyr`

### DIFF
--- a/moderntimeline.dtx
+++ b/moderntimeline.dtx
@@ -237,7 +237,7 @@
 % This macro places vertical lines on the timeline bar at every month and year.
 % You can set the height of the marks with |\tlmarkheightmo| (default = 0.2ex).
 %
-% \DescribeMacro{\tlenablemakrsyr}
+% \DescribeMacro{\tlenablemarksyr}
 % This macro places vertical lines on the timeline bar at every year.
 % You can set the height of the marks with |\tlmarkheightyr| (default = 0.4ex).
 %


### PR DESCRIPTION
makr → mark